### PR TITLE
New: Adding workflow updates the version in the package.json

### DIFF
--- a/.github/workflows/update-package-json.yml
+++ b/.github/workflows/update-package-json.yml
@@ -1,0 +1,29 @@
+name: Node.js Update Package-json version 
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      # Extract tag version from release event payload
+      - name: Extract tag version
+        id: extract-tag
+        run: echo "::set-output name=tag_version::${GITHUB_REF#refs/tags/}"
+
+      # Update package.json version
+      - name: Update package version
+        run: |
+          TAG_VERSION=${{ steps.extract-tag.outputs.tag_version }}
+          jq ".version = \"$TAG_VERSION\"" package.json > temp.json
+          mv temp.json package.json
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git commit -am "Bump version to $TAG_VERSION [skip ci]"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Actions workflow updates the version in the `package.json` file whenever a new `release` is created. 

### Workflow Triggers:

The workflow triggers on the release event with the created action type. This means it will run whenever a new release is created in the repository.

### Extract Tag Version:
Extracts the tag version from the GITHUB_REF environment variable and sets it as an output named tag_version.

### Update Package Version:
- Updates the version in the package.json file using jq, a command-line JSON processor and sets the version in package.json to the value obtained from the previous step.
- It then commits the changes to package.json, including a commit message indicating the version bump. The [skip ci] tag is included to skip CI builds triggered by this commit.